### PR TITLE
Database setup and Todo model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .venv/
 dist/
 *.egg-info/
+instance/
+*.db

--- a/src/todo_api/__init__.py
+++ b/src/todo_api/__init__.py
@@ -19,6 +19,12 @@ def create_app(config_name=None):
     db.init_app(app)
     ma.init_app(app)
 
+    # Import models so SQLAlchemy registers them before create_all
+    import todo_api.features.todos.models  # noqa: F401
+
+    from todo_api.infrastructure.database import init_db
+    init_db(app)
+
     @app.route("/health")
     def health():
         return {"status": "ok"}

--- a/src/todo_api/features/todos/domain.py
+++ b/src/todo_api/features/todos/domain.py
@@ -1,1 +1,15 @@
 """Todo domain model. Defines the Todo entity and related value objects with framework-agnostic business logic."""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class Todo:
+    """A todo item."""
+
+    title: str
+    completed: bool = False
+    id: int | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))

--- a/src/todo_api/features/todos/models.py
+++ b/src/todo_api/features/todos/models.py
@@ -1,0 +1,27 @@
+"""SQLAlchemy model for the Todo entity. Maps the domain Todo to a database table."""
+
+from datetime import datetime, timezone
+
+from todo_api.extensions import db
+
+
+class TodoModel(db.Model):
+    """SQLAlchemy model for the todos table."""
+
+    __tablename__ = "todos"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    completed = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    def __repr__(self):
+        return f"<TodoModel id={self.id} title={self.title!r}>"

--- a/src/todo_api/infrastructure/database.py
+++ b/src/todo_api/infrastructure/database.py
@@ -1,1 +1,9 @@
 """Database configuration and session management. Sets up SQLAlchemy engine, session factory, and base model class."""
+
+from todo_api.extensions import db
+
+
+def init_db(app):
+    """Create all database tables within the application context."""
+    with app.app_context():
+        db.create_all()

--- a/tests/features/todos/test_domain.py
+++ b/tests/features/todos/test_domain.py
@@ -1,1 +1,22 @@
-"""Tests for the todo domain model. Verifies entity creation, validation rules, and business logic behavior."""
+"""Tests for the Todo domain entity."""
+
+from datetime import datetime, timezone
+
+from todo_api.features.todos.domain import Todo
+
+
+def test_todo_defaults():
+    todo = Todo(title="Buy groceries")
+    assert todo.title == "Buy groceries"
+    assert todo.completed is False
+    assert todo.id is None
+    assert isinstance(todo.created_at, datetime)
+    assert todo.created_at.tzinfo == timezone.utc
+
+
+def test_todo_with_all_fields():
+    now = datetime.now(timezone.utc)
+    todo = Todo(id=1, title="Test", completed=True, created_at=now, updated_at=now)
+    assert todo.id == 1
+    assert todo.completed is True
+    assert todo.created_at == now

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,1 +1,26 @@
-"""Database integration tests. Verifies repository implementations against a real database instance."""
+"""Database integration tests. Verifies that the Todo model and database tables are created correctly."""
+
+from todo_api.extensions import db
+from todo_api.features.todos.models import TodoModel
+
+
+def test_todo_table_exists(app):
+    """Verify the todos table is created on app startup."""
+    with app.app_context():
+        inspector = db.inspect(db.engine)
+        assert "todos" in inspector.get_table_names()
+
+
+def test_todo_model_roundtrip(app):
+    """Verify a TodoModel can be saved and retrieved."""
+    with app.app_context():
+        todo = TodoModel(title="Integration test todo")
+        db.session.add(todo)
+        db.session.commit()
+
+        retrieved = db.session.get(TodoModel, todo.id)
+        assert retrieved is not None
+        assert retrieved.title == "Integration test todo"
+        assert retrieved.completed is False
+        assert retrieved.created_at is not None
+        assert retrieved.updated_at is not None


### PR DESCRIPTION
## Summary
- Add framework-agnostic `Todo` dataclass in `features/todos/domain.py` with fields: `id`, `title`, `completed`, `created_at`, `updated_at`
- Add `TodoModel` SQLAlchemy model in `features/todos/models.py` mapping to the `todos` table
- Add `init_db()` in `infrastructure/database.py` that creates all tables on app startup
- Update app factory to import models and call `init_db()`
- Add `.gitignore` entries for SQLite databases and the `instance/` directory

## Test plan
- [x] `test_todo_defaults` — domain entity created with correct defaults
- [x] `test_todo_with_all_fields` — domain entity accepts all fields
- [x] `test_todo_table_exists` — todos table created on app startup
- [x] `test_todo_model_roundtrip` — save and retrieve a TodoModel from the database
- [x] All 5 tests pass (`uv run pytest`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)