### PR TITLE
Todo repository — port and SQL adapter

### DIFF
--- a/src/todo_api/features/todos/adapters/sql_repository.py
+++ b/src/todo_api/features/todos/adapters/sql_repository.py
@@ -1,1 +1,52 @@
 """SQL-based todo repository adapter. Implements the todo repository port using SQLAlchemy for relational database persistence."""
+
+from todo_api.extensions import db
+from todo_api.features.todos.domain import Todo
+from todo_api.features.todos.models import TodoModel
+
+
+class SqlTodoRepository:
+    """SQLAlchemy implementation of the TodoRepository port."""
+
+    def get_all(self) -> list[Todo]:
+        models = db.session.query(TodoModel).order_by(TodoModel.created_at).all()
+        return [self._to_domain(m) for m in models]
+
+    def get_by_id(self, todo_id: int) -> Todo | None:
+        model = db.session.get(TodoModel, todo_id)
+        if model is None:
+            return None
+        return self._to_domain(model)
+
+    def create(self, todo: Todo) -> Todo:
+        model = TodoModel(title=todo.title, completed=todo.completed)
+        db.session.add(model)
+        db.session.commit()
+        return self._to_domain(model)
+
+    def update(self, todo: Todo) -> Todo | None:
+        model = db.session.get(TodoModel, todo.id)
+        if model is None:
+            return None
+        model.title = todo.title
+        model.completed = todo.completed
+        db.session.commit()
+        return self._to_domain(model)
+
+    def delete(self, todo_id: int) -> bool:
+        model = db.session.get(TodoModel, todo_id)
+        if model is None:
+            return False
+        db.session.delete(model)
+        db.session.commit()
+        return True
+
+    @staticmethod
+    def _to_domain(model: TodoModel) -> Todo:
+        return Todo(
+            id=model.id,
+            title=model.title,
+            completed=model.completed,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )

--- a/src/todo_api/features/todos/repository.py
+++ b/src/todo_api/features/todos/repository.py
@@ -1,1 +1,19 @@
 """Todo repository port. Defines the Protocol (interface) for todo persistence operations, independent of any specific storage implementation."""
+
+from typing import Protocol
+
+from todo_api.features.todos.domain import Todo
+
+
+class TodoRepository(Protocol):
+    """Port for todo persistence operations."""
+
+    def get_all(self) -> list[Todo]: ...
+
+    def get_by_id(self, todo_id: int) -> Todo | None: ...
+
+    def create(self, todo: Todo) -> Todo: ...
+
+    def update(self, todo: Todo) -> Todo | None: ...
+
+    def delete(self, todo_id: int) -> bool: ...

--- a/tests/features/todos/test_repository.py
+++ b/tests/features/todos/test_repository.py
@@ -1,0 +1,71 @@
+"""Tests for the SQL todo repository adapter. Verifies CRUD operations against an in-memory database."""
+
+import pytest
+
+from todo_api.features.todos.adapters.sql_repository import SqlTodoRepository
+from todo_api.features.todos.domain import Todo
+
+
+@pytest.fixture
+def repo(app):
+    """Provide a SqlTodoRepository within an app context."""
+    with app.app_context():
+        yield SqlTodoRepository()
+
+
+def test_create_and_get_by_id(repo):
+    todo = repo.create(Todo(title="Write tests"))
+    assert todo.id is not None
+    assert todo.title == "Write tests"
+    assert todo.completed is False
+
+    retrieved = repo.get_by_id(todo.id)
+    assert retrieved is not None
+    assert retrieved.title == "Write tests"
+
+
+def test_get_all_returns_all_todos(repo):
+    repo.create(Todo(title="First"))
+    repo.create(Todo(title="Second"))
+
+    todos = repo.get_all()
+    assert len(todos) == 2
+    assert todos[0].title == "First"
+    assert todos[1].title == "Second"
+
+
+def test_get_all_empty(repo):
+    assert repo.get_all() == []
+
+
+def test_get_by_id_not_found(repo):
+    assert repo.get_by_id(999) is None
+
+
+def test_update(repo):
+    todo = repo.create(Todo(title="Original"))
+    todo.title = "Updated"
+    todo.completed = True
+
+    updated = repo.update(todo)
+    assert updated is not None
+    assert updated.title == "Updated"
+    assert updated.completed is True
+
+    retrieved = repo.get_by_id(todo.id)
+    assert retrieved.title == "Updated"
+
+
+def test_update_not_found(repo):
+    result = repo.update(Todo(id=999, title="Ghost"))
+    assert result is None
+
+
+def test_delete(repo):
+    todo = repo.create(Todo(title="To delete"))
+    assert repo.delete(todo.id) is True
+    assert repo.get_by_id(todo.id) is None
+
+
+def test_delete_not_found(repo):
+    assert repo.delete(999) is False


### PR DESCRIPTION
## Summary
- Define `TodoRepository` Protocol in `features/todos/repository.py` with methods: `get_all()`, `get_by_id()`, `create()`, `update()`, `delete()`
- Implement `SqlTodoRepository` in `features/todos/adapters/sql_repository.py` using SQLAlchemy with domain-model mapping
- Add 8 unit tests covering all CRUD operations and not-found edge cases

## Test plan
- [x] `test_create_and_get_by_id` — create a todo and retrieve it by ID
- [x] `test_get_all_returns_all_todos` — returns all todos in order
- [x] `test_get_all_empty` — returns empty list when no todos exist
- [x] `test_get_by_id_not_found` — returns None for nonexistent ID
- [x] `test_update` — updates title and completed fields
- [x] `test_update_not_found` — returns None for nonexistent ID
- [x] `test_delete` — deletes a todo and confirms it's gone
- [x] `test_delete_not_found` — returns False for nonexistent ID
- [x] All 13 tests pass (`uv run pytest`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)