### PR TITLE
REST API endpoints for todos

### DIFF
--- a/src/todo_api/__init__.py
+++ b/src/todo_api/__init__.py
@@ -25,6 +25,9 @@ def create_app(config_name=None):
     from todo_api.infrastructure.database import init_db
     init_db(app)
 
+    from todo_api.features.todos.rest import bp as todos_bp
+    app.register_blueprint(todos_bp)
+
     @app.route("/health")
     def health():
         return {"status": "ok"}

--- a/src/todo_api/features/todos/rest/__init__.py
+++ b/src/todo_api/features/todos/rest/__init__.py
@@ -1,1 +1,3 @@
 """REST interface for the todos feature. Registers the Flask Blueprint for todo REST endpoints."""
+
+from todo_api.features.todos.rest.routes import bp

--- a/src/todo_api/features/todos/rest/routes.py
+++ b/src/todo_api/features/todos/rest/routes.py
@@ -1,1 +1,76 @@
 """Todo REST route definitions. Defines Flask routes for CRUD operations on todos, handling HTTP request/response concerns."""
+
+from flask import Blueprint, request
+
+from todo_api.core.exceptions import NotFoundError, ValidationError
+from todo_api.features.todos.adapters.sql_repository import SqlTodoRepository
+from todo_api.features.todos.rest.schemas import (
+    create_todo_schema,
+    todo_schema,
+    todos_schema,
+)
+from todo_api.features.todos.service import TodoService
+
+bp = Blueprint("todos", __name__, url_prefix="/api/todos")
+
+
+def _get_service() -> TodoService:
+    return TodoService(repository=SqlTodoRepository())
+
+
+@bp.errorhandler(NotFoundError)
+def handle_not_found(error):
+    return {"error": str(error)}, 404
+
+
+@bp.errorhandler(ValidationError)
+def handle_validation(error):
+    return {"error": str(error)}, 400
+
+
+@bp.route("", methods=["GET"])
+def list_todos():
+    """List all todos."""
+    service = _get_service()
+    todos = service.list_todos()
+    return todos_schema.dump(todos), 200
+
+
+@bp.route("/<int:todo_id>", methods=["GET"])
+def get_todo(todo_id):
+    """Get a single todo by ID."""
+    service = _get_service()
+    todo = service.get_todo(todo_id)
+    return todo_schema.dump(todo), 200
+
+
+@bp.route("", methods=["POST"])
+def create_todo():
+    """Create a new todo."""
+    data = request.get_json()
+    if not data or "title" not in data:
+        return {"error": "Request must include a JSON body with a 'title' field"}, 400
+
+    errors = create_todo_schema.validate(data)
+    if errors:
+        return {"error": errors}, 400
+
+    service = _get_service()
+    todo = service.create_todo(data["title"])
+    return todo_schema.dump(todo), 201
+
+
+@bp.route("/<int:todo_id>", methods=["PATCH"])
+def toggle_todo(todo_id):
+    """Toggle the completed status of a todo."""
+    service = _get_service()
+    todo = service.toggle_completed(todo_id)
+    return todo_schema.dump(todo), 200
+
+
+@bp.route("/<int:todo_id>", methods=["DELETE"])
+def delete_todo(todo_id):
+    """Delete a todo."""
+    service = _get_service()
+    service.delete_todo(todo_id)
+    return "", 204

--- a/src/todo_api/features/todos/rest/schemas.py
+++ b/src/todo_api/features/todos/rest/schemas.py
@@ -1,1 +1,26 @@
-"""Todo REST serialization schemas. Defines Marshmallow or Pydantic schemas for request validation and response serialization."""
+"""Todo REST serialization schemas. Defines Marshmallow schemas for request validation and response serialization."""
+
+from marshmallow import fields
+
+from todo_api.extensions import ma
+
+
+class TodoSchema(ma.Schema):
+    """Schema for serializing Todo responses."""
+
+    id = fields.Integer(dump_only=True)
+    title = fields.String(required=True)
+    completed = fields.Boolean(dump_only=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class CreateTodoSchema(ma.Schema):
+    """Schema for validating create todo requests."""
+
+    title = fields.String(required=True)
+
+
+todo_schema = TodoSchema()
+todos_schema = TodoSchema(many=True)
+create_todo_schema = CreateTodoSchema()

--- a/tests/features/todos/test_rest.py
+++ b/tests/features/todos/test_rest.py
@@ -1,1 +1,123 @@
 """Tests for the todo REST endpoints. Verifies HTTP request handling, response formats, and status codes."""
+
+import json
+
+
+def test_list_todos_empty(client):
+    response = client.get("/api/todos")
+    assert response.status_code == 200
+    assert response.get_json() == []
+
+
+def test_create_todo(client):
+    response = client.post(
+        "/api/todos",
+        data=json.dumps({"title": "Buy milk"}),
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["title"] == "Buy milk"
+    assert data["completed"] is False
+    assert "id" in data
+
+
+def test_create_todo_missing_title(client):
+    response = client.post(
+        "/api/todos",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_create_todo_blank_title(client):
+    response = client.post(
+        "/api/todos",
+        data=json.dumps({"title": "   "}),
+        content_type="application/json",
+    )
+    assert response.status_code == 400
+
+
+def test_create_todo_no_body(client):
+    response = client.post("/api/todos", content_type="application/json")
+    assert response.status_code == 400
+
+
+def test_list_todos_after_create(client):
+    client.post(
+        "/api/todos",
+        data=json.dumps({"title": "First"}),
+        content_type="application/json",
+    )
+    client.post(
+        "/api/todos",
+        data=json.dumps({"title": "Second"}),
+        content_type="application/json",
+    )
+    response = client.get("/api/todos")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data) == 2
+
+
+def test_get_todo(client):
+    create_resp = client.post(
+        "/api/todos",
+        data=json.dumps({"title": "Get me"}),
+        content_type="application/json",
+    )
+    todo_id = create_resp.get_json()["id"]
+
+    response = client.get(f"/api/todos/{todo_id}")
+    assert response.status_code == 200
+    assert response.get_json()["title"] == "Get me"
+
+
+def test_get_todo_not_found(client):
+    response = client.get("/api/todos/999")
+    assert response.status_code == 404
+    assert "error" in response.get_json()
+
+
+def test_toggle_todo(client):
+    create_resp = client.post(
+        "/api/todos",
+        data=json.dumps({"title": "Toggle me"}),
+        content_type="application/json",
+    )
+    todo_id = create_resp.get_json()["id"]
+
+    response = client.patch(f"/api/todos/{todo_id}")
+    assert response.status_code == 200
+    assert response.get_json()["completed"] is True
+
+    response = client.patch(f"/api/todos/{todo_id}")
+    assert response.status_code == 200
+    assert response.get_json()["completed"] is False
+
+
+def test_toggle_todo_not_found(client):
+    response = client.patch("/api/todos/999")
+    assert response.status_code == 404
+
+
+def test_delete_todo(client):
+    create_resp = client.post(
+        "/api/todos",
+        data=json.dumps({"title": "Delete me"}),
+        content_type="application/json",
+    )
+    todo_id = create_resp.get_json()["id"]
+
+    response = client.delete(f"/api/todos/{todo_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/api/todos/{todo_id}")
+    assert response.status_code == 404
+
+
+def test_delete_todo_not_found(client):
+    response = client.delete("/api/todos/999")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Add Flask Blueprint with routes in `features/todos/rest/routes.py` for all CRUD operations
- Add Marshmallow schemas in `features/todos/rest/schemas.py` for request validation and response serialization
- Register Blueprint in app factory at `/api/todos` prefix
- Endpoints:
  - `GET /api/todos` — list all todos
  - `GET /api/todos/:id` — get a single todo
  - `POST /api/todos` — create a todo (requires JSON body with `title`)
  - `PATCH /api/todos/:id` — toggle completed status
  - `DELETE /api/todos/:id` — delete a todo
- Error handlers return 400 for validation errors and 404 for not-found

## Test plan
- [x] `test_list_todos_empty` — returns empty array
- [x] `test_create_todo` — creates and returns todo with 201
- [x] `test_create_todo_missing_title` / `test_create_todo_blank_title` / `test_create_todo_no_body` — returns 400
- [x] `test_list_todos_after_create` — returns all created todos
- [x] `test_get_todo` / `test_get_todo_not_found` — returns todo or 404
- [x] `test_toggle_todo` / `test_toggle_todo_not_found` — toggles completed or 404
- [x] `test_delete_todo` / `test_delete_todo_not_found` — deletes with 204 or 404
- [x] All 37 tests pass (`uv run pytest`)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)