### PR TITLE
GraphQL API for todos

### DIFF
--- a/src/todo_api/__init__.py
+++ b/src/todo_api/__init__.py
@@ -28,6 +28,16 @@ def create_app(config_name=None):
     from todo_api.features.todos.rest import bp as todos_bp
     app.register_blueprint(todos_bp)
 
+    from todo_api.graphql import schema
+    from ariadne import graphql_sync
+    from flask import request, jsonify
+
+    @app.route("/graphql", methods=["POST"])
+    def graphql_endpoint():
+        data = request.get_json()
+        success, result = graphql_sync(schema, data, context_value={"request": request})
+        return jsonify(result), 200 if success else 400
+
     @app.route("/health")
     def health():
         return {"status": "ok"}

--- a/src/todo_api/features/todos/graphql/__init__.py
+++ b/src/todo_api/features/todos/graphql/__init__.py
@@ -1,1 +1,5 @@
 """GraphQL interface for the todos feature. Exports queries, mutations, and types for the todos feature slice."""
+
+from todo_api.features.todos.graphql.mutations import mutation
+from todo_api.features.todos.graphql.queries import query
+from todo_api.features.todos.graphql.types import type_defs

--- a/src/todo_api/features/todos/graphql/mutations.py
+++ b/src/todo_api/features/todos/graphql/mutations.py
@@ -1,1 +1,31 @@
 """Todo GraphQL mutation definitions. Defines resolver functions for creating, updating, and deleting todos via GraphQL."""
+
+from ariadne import MutationType
+
+from todo_api.features.todos.adapters.sql_repository import SqlTodoRepository
+from todo_api.features.todos.service import TodoService
+
+mutation = MutationType()
+
+
+def _get_service() -> TodoService:
+    return TodoService(repository=SqlTodoRepository())
+
+
+@mutation.field("createTodo")
+def resolve_create_todo(*_, title):
+    service = _get_service()
+    return service.create_todo(title)
+
+
+@mutation.field("toggleTodo")
+def resolve_toggle_todo(*_, id):
+    service = _get_service()
+    return service.toggle_completed(int(id))
+
+
+@mutation.field("deleteTodo")
+def resolve_delete_todo(*_, id):
+    service = _get_service()
+    service.delete_todo(int(id))
+    return {"success": True}

--- a/src/todo_api/features/todos/graphql/queries.py
+++ b/src/todo_api/features/todos/graphql/queries.py
@@ -1,1 +1,24 @@
 """Todo GraphQL query definitions. Defines resolver functions for reading and listing todos via GraphQL."""
+
+from ariadne import QueryType
+
+from todo_api.features.todos.adapters.sql_repository import SqlTodoRepository
+from todo_api.features.todos.service import TodoService
+
+query = QueryType()
+
+
+def _get_service() -> TodoService:
+    return TodoService(repository=SqlTodoRepository())
+
+
+@query.field("todos")
+def resolve_todos(*_):
+    service = _get_service()
+    return service.list_todos()
+
+
+@query.field("todo")
+def resolve_todo(*_, id):
+    service = _get_service()
+    return service.get_todo(int(id))

--- a/src/todo_api/features/todos/graphql/types.py
+++ b/src/todo_api/features/todos/graphql/types.py
@@ -1,1 +1,15 @@
-"""Todo GraphQL type definitions. Defines GraphQL object types, input types, and enums for the todos feature."""
+"""Todo GraphQL type definitions. Defines the GraphQL SDL for the todos feature."""
+
+type_defs = """
+    type Todo {
+        id: ID!
+        title: String!
+        completed: Boolean!
+        createdAt: String!
+        updatedAt: String!
+    }
+
+    type DeleteResult {
+        success: Boolean!
+    }
+"""

--- a/src/todo_api/graphql/__init__.py
+++ b/src/todo_api/graphql/__init__.py
@@ -1,1 +1,3 @@
 """Application-level GraphQL package. Assembles feature-level GraphQL types, queries, and mutations into a unified schema."""
+
+from todo_api.graphql.schema import schema

--- a/src/todo_api/graphql/schema.py
+++ b/src/todo_api/graphql/schema.py
@@ -1,1 +1,26 @@
 """Unified GraphQL schema assembly. Composes feature-level queries and mutations into a single executable GraphQL schema."""
+
+from ariadne import make_executable_schema, snake_case_fallback_resolvers
+
+from todo_api.features.todos.graphql import mutation, query, type_defs
+
+# Root type definitions that compose the feature types
+root_type_defs = """
+    type Query {
+        todos: [Todo!]!
+        todo(id: ID!): Todo!
+    }
+
+    type Mutation {
+        createTodo(title: String!): Todo!
+        toggleTodo(id: ID!): Todo!
+        deleteTodo(id: ID!): DeleteResult!
+    }
+"""
+
+schema = make_executable_schema(
+    [root_type_defs, type_defs],
+    query,
+    mutation,
+    snake_case_fallback_resolvers,
+)

--- a/tests/features/todos/test_graphql.py
+++ b/tests/features/todos/test_graphql.py
@@ -1,1 +1,106 @@
 """Tests for the todo GraphQL interface. Verifies query and mutation resolvers produce correct results."""
+
+import json
+
+
+def _query(client, query, variables=None):
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    return client.post(
+        "/graphql",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+# Queries
+
+def test_todos_query_empty(client):
+    response = _query(client, "{ todos { id title completed } }")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["data"]["todos"] == []
+
+
+def test_todos_query_after_create(client):
+    _query(client, 'mutation { createTodo(title: "First") { id } }')
+    _query(client, 'mutation { createTodo(title: "Second") { id } }')
+
+    response = _query(client, "{ todos { id title completed } }")
+    data = response.get_json()
+    assert len(data["data"]["todos"]) == 2
+
+
+def test_todo_query(client):
+    create_resp = _query(client, 'mutation { createTodo(title: "Find me") { id } }')
+    todo_id = create_resp.get_json()["data"]["createTodo"]["id"]
+
+    response = _query(client, "query($id: ID!) { todo(id: $id) { id title completed createdAt updatedAt } }", {"id": todo_id})
+    data = response.get_json()
+    assert data["data"]["todo"]["title"] == "Find me"
+    assert data["data"]["todo"]["completed"] is False
+    assert data["data"]["todo"]["createdAt"] is not None
+
+
+def test_todo_query_not_found(client):
+    response = _query(client, '{ todo(id: "999") { id title } }')
+    data = response.get_json()
+    assert data.get("errors") is not None
+
+
+# Mutations
+
+def test_create_todo_mutation(client):
+    response = _query(client, 'mutation { createTodo(title: "New todo") { id title completed } }')
+    assert response.status_code == 200
+    data = response.get_json()
+    todo = data["data"]["createTodo"]
+    assert todo["title"] == "New todo"
+    assert todo["completed"] is False
+    assert todo["id"] is not None
+
+
+def test_create_todo_blank_title(client):
+    response = _query(client, 'mutation { createTodo(title: "   ") { id } }')
+    data = response.get_json()
+    assert data.get("errors") is not None
+
+
+def test_toggle_todo_mutation(client):
+    create_resp = _query(client, 'mutation { createTodo(title: "Toggle me") { id } }')
+    todo_id = create_resp.get_json()["data"]["createTodo"]["id"]
+
+    response = _query(client, "mutation($id: ID!) { toggleTodo(id: $id) { id completed } }", {"id": todo_id})
+    data = response.get_json()
+    assert data["data"]["toggleTodo"]["completed"] is True
+
+    response = _query(client, "mutation($id: ID!) { toggleTodo(id: $id) { id completed } }", {"id": todo_id})
+    data = response.get_json()
+    assert data["data"]["toggleTodo"]["completed"] is False
+
+
+def test_toggle_todo_not_found(client):
+    response = _query(client, 'mutation { toggleTodo(id: "999") { id } }')
+    data = response.get_json()
+    assert data.get("errors") is not None
+
+
+def test_delete_todo_mutation(client):
+    create_resp = _query(client, 'mutation { createTodo(title: "Delete me") { id } }')
+    todo_id = create_resp.get_json()["data"]["createTodo"]["id"]
+
+    response = _query(client, "mutation($id: ID!) { deleteTodo(id: $id) { success } }", {"id": todo_id})
+    data = response.get_json()
+    assert data["data"]["deleteTodo"]["success"] is True
+
+    # Verify it's gone
+    response = _query(client, "query($id: ID!) { todo(id: $id) { id } }", {"id": todo_id})
+    data = response.get_json()
+    assert data.get("errors") is not None
+
+
+def test_delete_todo_not_found(client):
+    response = _query(client, 'mutation { deleteTodo(id: "999") { success } }')
+    data = response.get_json()
+    assert data.get("errors") is not None


### PR DESCRIPTION
## Summary
- Define GraphQL SDL types (`Todo`, `DeleteResult`) in `features/todos/graphql/types.py`
- Add query resolvers (`todos`, `todo(id)`) in `features/todos/graphql/queries.py`
- Add mutation resolvers (`createTodo`, `toggleTodo`, `deleteTodo`) in `features/todos/graphql/mutations.py`
- Assemble unified schema in `graphql/schema.py` using `make_executable_schema` with `snake_case_fallback_resolvers`
- Mount `POST /graphql` endpoint in app factory using Ariadne's `graphql_sync`
- All resolvers delegate to the same `TodoService` used by REST

## Test plan
- [x] `test_todos_query_empty` — returns empty list
- [x] `test_todos_query_after_create` — returns all created todos
- [x] `test_todo_query` / `test_todo_query_not_found` — fetch single todo or get error
- [x] `test_create_todo_mutation` / `test_create_todo_blank_title` — create or validation error
- [x] `test_toggle_todo_mutation` / `test_toggle_todo_not_found` — toggle or error
- [x] `test_delete_todo_mutation` / `test_delete_todo_not_found` — delete or error
- [x] All 47 tests pass (`uv run pytest`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)