### PR TITLE
Add OpenAPI 3.0.3 spec served at /api/docs

### DIFF
--- a/docs/adr/006-openapi-specification.md
+++ b/docs/adr/006-openapi-specification.md
@@ -1,0 +1,33 @@
+# ADR-006: OpenAPI Specification
+
+## Status
+
+Accepted
+
+## Context
+
+The todo-api exposes a REST interface but lacked a formal, machine-readable API contract. Without one, API consumers (e.g., the todo-web frontend, external integrations, or automated tooling) must infer the contract from source code or ad-hoc documentation. A machine-readable spec enables client SDK generation, interactive documentation, and contract validation.
+
+## Decision
+
+Maintain a static `openapi.yaml` file (OpenAPI 3.0.3) co-located with the application package at `src/todo_api/openapi.yaml`. The spec is served as-is at `GET /api/docs` with `Content-Type: application/yaml`.
+
+**Key choices:**
+
+- **Static file, not code-generated.** The API surface is small and stable. Code-generation libraries (e.g., `apispec`, `flask-smorest`) add complexity and require restructuring routes or adding decorators. A static file is easier to read, review, and keep accurate for this scale.
+- **OpenAPI 3.0.3, not 3.1.x.** 3.0.3 has broader tooling support (validators, Swagger UI, code generators) than the newer 3.1 series.
+- **Served raw as YAML, not parsed and re-serialised as JSON.** Avoids adding `pyyaml` as a runtime dependency. Clients that require JSON can convert locally; Swagger UI and most tooling accept YAML natively.
+- **Endpoint at `/api/docs`.** Consistent with the `/api/` prefix used by REST routes. Returns the spec directly rather than rendering a full Swagger UI, keeping the server dependency-free.
+
+## Alternatives Considered
+
+- **`flask-smorest`** — tightly integrated OpenAPI generation with Marshmallow. Requires migrating route definitions to its `MethodView`-based API, which is a larger change than warranted at this stage.
+- **`apispec` + plugins** — annotation-driven generation from existing routes and schemas. Adds runtime dependencies and docstring-based annotations that couple documentation to implementation details.
+- **Serving Swagger UI** — embedding the Swagger UI static bundle adds significant weight and a maintenance surface. Consumers can point any Swagger UI instance at `/api/docs` themselves.
+
+## Consequences
+
+- The spec must be updated manually when REST routes change. The GraphQL interface is not covered (it has its own introspection mechanism).
+- No new runtime dependencies are introduced.
+- External tools (Swagger UI, Postman, code generators) can be pointed at `/api/docs` to interact with or generate clients for the API.
+- Contract validation can be added to CI by linting `openapi.yaml` with a tool such as Spectral.

--- a/src/todo_api/__init__.py
+++ b/src/todo_api/__init__.py
@@ -1,6 +1,7 @@
 """Todo API application package. Contains the Flask application factory and top-level configuration."""
 
 import os
+from pathlib import Path
 
 from flask import Flask
 
@@ -41,5 +42,10 @@ def create_app(config_name=None):
     @app.route("/health")
     def health():
         return {"status": "ok"}
+
+    @app.route("/api/docs")
+    def openapi_spec():
+        spec_path = Path(app.root_path) / "openapi.yaml"
+        return spec_path.read_text(), 200, {"Content-Type": "application/yaml"}
 
     return app

--- a/src/todo_api/openapi.yaml
+++ b/src/todo_api/openapi.yaml
@@ -1,0 +1,165 @@
+openapi: "3.0.3"
+
+info:
+  title: Todo API
+  version: "1.0.0"
+  description: REST API for managing todo items.
+
+servers:
+  - url: http://localhost:5000
+    description: Local development server
+
+paths:
+  /api/todos:
+    get:
+      summary: List all todos
+      operationId: listTodos
+      responses:
+        "200":
+          description: A list of todos
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Todo"
+
+    post:
+      summary: Create a todo
+      operationId: createTodo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTodo"
+      responses:
+        "201":
+          description: Todo created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Todo"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/todos/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+
+    get:
+      summary: Get a todo by ID
+      operationId: getTodo
+      responses:
+        "200":
+          description: The requested todo
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Todo"
+        "404":
+          description: Todo not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    patch:
+      summary: Toggle a todo's completed status
+      operationId: toggleTodo
+      responses:
+        "200":
+          description: The updated todo
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Todo"
+        "404":
+          description: Todo not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    delete:
+      summary: Delete a todo
+      operationId: deleteTodo
+      responses:
+        "204":
+          description: Todo deleted
+        "404":
+          description: Todo not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /health:
+    get:
+      summary: Health check
+      operationId: healthCheck
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                required:
+                  - status
+
+components:
+  schemas:
+    Todo:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        completed:
+          type: boolean
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+        - id
+        - title
+        - completed
+        - created_at
+        - updated_at
+
+    CreateTodo:
+      type: object
+      properties:
+        title:
+          type: string
+      required:
+        - title
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+      required:
+        - error


### PR DESCRIPTION
## Summary

- Adds `src/todo_api/openapi.yaml` — an OpenAPI 3.0.3 spec covering all REST endpoints (list, create, get, toggle, delete todos, and health check)
- Serves the spec raw as YAML at `GET /api/docs` with no new runtime dependencies
- Adds ADR-006 documenting the static-file approach and trade-offs considered

## Test plan

- [x] All 47 existing tests pass (`uv run pytest`)
- [x] `GET /api/docs` returns the YAML spec with `Content-Type: application/yaml`
- [x] Spec can be pasted into [Swagger Editor](https://editor.swagger.io) and validates cleanly

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)